### PR TITLE
Added exception logging

### DIFF
--- a/app/code/community/Shippit/Shippit/Model/Shipping/Carrier/Shippit.php
+++ b/app/code/community/Shippit/Shippit/Model/Shipping/Carrier/Shippit.php
@@ -97,10 +97,8 @@ class Shippit_Shippit_Model_Shipping_Carrier_Shippit extends Shippit_Shippit_Mod
             $shippingQuotes = $this->api->getQuote($quoteRequest);
         }
         catch (Exception $e) {
-			if ( Mage::helper( "shippit" )->isDebugActive() ) {
-		        Mage::logException( $e );
-	        }
-            return false;
+	        $this->logger->logException($e);
+	        return false;
         }
 
         $this->_processShippingQuotes($rateResult, $shippingQuotes);

--- a/app/code/community/Shippit/Shippit/Model/Shipping/Carrier/Shippit.php
+++ b/app/code/community/Shippit/Shippit/Model/Shipping/Carrier/Shippit.php
@@ -97,6 +97,9 @@ class Shippit_Shippit_Model_Shipping_Carrier_Shippit extends Shippit_Shippit_Mod
             $shippingQuotes = $this->api->getQuote($quoteRequest);
         }
         catch (Exception $e) {
+			if ( Mage::helper( "shippit" )->isDebugActive() ) {
+		        Mage::logException( $e );
+	        }
             return false;
         }
 


### PR DESCRIPTION
 Added logging for app\code\community\Shippit\Shippit\Model\Shipping\Carrier\Shippit.php because there was an issue with the shippit tablerates not rendering. The issue was actually API related. This should help in finding error s and solving them as they will be written to the standard var/log/exception.log (if the debug setting is on)